### PR TITLE
🔧 chore(ci): add daily scheduled release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ name: Build & Release Tailscale ACAP
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'  # Run daily at midnight UTC
 
 # Global environment variables available to all jobs
 env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Global ARG declarations - must be at the top, before ANY FROM statement
-ARG GO_VERSION=1.24
+ARG GO_VERSION=1.25
 ARG TAILSCALE_VERSION # Set via --build-arg or determined in builder stage
 ARG GOOS=linux
 ARG GOARCH # Set via --build-arg


### PR DESCRIPTION
Added automated daily release builds triggered at midnight UTC while preserving manual trigger capability. This helps ensure regular package updates and improves release automation consistency.